### PR TITLE
reduce constant logging of job data

### DIFF
--- a/lib/processing/jobProcessingService.js
+++ b/lib/processing/jobProcessingService.js
@@ -30,17 +30,15 @@ class JobProcessingService {
   registerJobProcessor(jobType, processFunction, concurrency) {
     this._queue.process(jobType, concurrency || 1, (job, done) => {
       return Promise.resolve()
-      .then(() => this._logger.info('Job starting', {jobId: job.id, data: job.data}))
+      .tap(() => this._logger.info(`job.start id:${job.id}`))
       .then(() => processFunction(job.id, job.data))
-      .then(result => {
-        this._logger.info('Job completed', {jobId: job.id, result: result, data: job.data});
-        done(null, result);
-      })
-      .catch(err => {
-        this._logger.error('Job failed', {jobId: job.id, data: job.data, err:err});
+      .tap(() => this._logger.info(`job.finish id:${job.id}`))
+      .then(result => done(null, result))
+      .catch((err) => {
+        this._logger.error(`job.fail id:${job.id}`);
         done(err);
-      })
-    })
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
Logs currently spout tons of JSON data -- this should be the responsibility of the callers, not the utility.